### PR TITLE
fix notifications for sdk28 (also works for lower SDKs)

### DIFF
--- a/fadecandy-service/build.gradle
+++ b/fadecandy-service/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion "26.0.3"
 
     lintOptions {
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 7
         versionName "1.62"
 

--- a/fadecandy-service/src/main/java/fr/bmartel/android/fadecandy/service/FadecandyService.kt
+++ b/fadecandy-service/src/main/java/fr/bmartel/android/fadecandy/service/FadecandyService.kt
@@ -418,7 +418,7 @@ class FadecandyService : Service() {
                 return Service.START_NOT_STICKY
             }
             ServiceType.PERSISTENT_SERVICE -> {
-                startForeground(4242, NotificationHelper.createNotification(this, null, testIntent))
+                startForeground(1, NotificationHelper.createNotification(this, null, testIntent))
                 Log.v(TAG, "starting PERSISTENT_SERVICE...")
                 return Service.START_STICKY
             }

--- a/fadecandy-service/src/main/java/fr/bmartel/android/fadecandy/utils/NotificationHelper.kt
+++ b/fadecandy-service/src/main/java/fr/bmartel/android/fadecandy/utils/NotificationHelper.kt
@@ -28,9 +28,12 @@
 package fr.bmartel.android.fadecandy.utils
 
 import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.support.v4.app.NotificationCompat
 
 import fr.bmartel.android.fadecandy.R
@@ -42,6 +45,10 @@ import fr.bmartel.android.fadecandy.service.FadecandyService
  * @author Bertrand Martel
  */
 object NotificationHelper {
+
+    val CHANNEL_ID = "fadecandyServiceChannelID"
+    val CHANNEL_NAME = "fadecandyServiceChannel"
+    val CHANNEL_DESCRIPTION = "FadeCandy Service Channel"
 
     /**
      * Create the intent to be launched when user click on notification.
@@ -66,16 +73,19 @@ object NotificationHelper {
      */
     fun createNotification(context: Context, content: String?, activityIntent: Intent): Notification {
 
+        createNotificationChannel(context)
+
         val title = context.getString(R.string.app_name)
         val pendingIntent = createLaunchIntent(context = context, activityIntent = activityIntent)
 
-        val builder = NotificationCompat.Builder(context)
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
                 .setContentTitle(title)
                 .setSmallIcon(R.mipmap.ic_launcher)
                 .setContentText(content)
                 .setContentIntent(pendingIntent)
                 .setPriority(NotificationCompat.PRIORITY_HIGH)
                 .setOngoing(true)
+                .setChannelId(CHANNEL_ID)
 
         val yesReceive = Intent()
         yesReceive.action = FadecandyService.ACTION_EXIT
@@ -84,4 +94,20 @@ object NotificationHelper {
 
         return builder.build()
     }
+
+    private fun createNotificationChannel(context: Context) {
+        // Create the NotificationChannel, but only on API 26+ because
+        // the NotificationChannel class is new and not in the support library
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O)
+            return
+
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager?
+        if (notificationManager!!.getNotificationChannel(CHANNEL_ID) != null)
+            return
+
+        val channel = NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_DEFAULT)
+        channel.description = CHANNEL_DESCRIPTION
+        notificationManager.createNotificationChannel(channel) // Register the channel with the system; you can't change the importance or other notification behaviors after this
+    }
+
 }


### PR DESCRIPTION
When trying to run the app on Android 9 it crashes on notification channel exception.
This PR fixes this issue.